### PR TITLE
added check whether drb exists in alert

### DIFF
--- a/ampel/ztf/t0/DecentFilter.py
+++ b/ampel/ztf/t0/DecentFilter.py
@@ -280,10 +280,11 @@ class DecentFilter(CatalogMatchUnit, AbsAlertFilter):
             self.logger.debug(None, extra={"rb": latest["rb"]})
             return None
 
-        if self.min_drb > 0.0 and latest["drb"] < self.min_drb:
-            # self.logger.debug("rejected: RB score %.2f below threshod (%.2f)"% (latest['rb'], self.min_rb))
-            self.logger.debug(None, extra={"drb": latest["drb"]})
-            return None
+        if "drb" in latest: # some older alerts dont have drb, dont want to leave them out entirely but need check
+            if self.min_drb > 0.0 and latest["drb"] < self.min_drb:
+                # self.logger.debug("rejected: RB score %.2f below threshod (%.2f)"% (latest['rb'], self.min_rb))
+                self.logger.debug(None, extra={"drb": latest["drb"]})
+                return None
 
         if latest["fwhm"] > self.max_fwhm:
             # self.logger.debug("rejected: fwhm %.2f above threshod (%.2f)"% (latest['fwhm'], self.max_fwhm))


### PR DESCRIPTION
`DecentFilter._alert_has_keys()` does not check for `drb` score, which some older alert don't have, throwing an error later on. We don't want to completely discard alerts lacking drb so I did not add it to `_alert_has_keys()` but as a separate check.