### PR TITLE
Allow floating (JD) time offsets.

### DIFF
--- a/ampel/ztf/t3/resource/T3ZTFArchiveTokenGenerator.py
+++ b/ampel/ztf/t3/resource/T3ZTFArchiveTokenGenerator.py
@@ -38,7 +38,7 @@ class T3ZTFArchiveTokenGenerator(AbsT3PlainUnit):
 	date_format: str = "%Y-%m-%d"
 	delta_t: float = 1.0         # Length of time window from start date (days)
 	
-	days_ago: None | int = None
+	days_ago: None | float = None
 
 	#: overrides max_dist_ps1_src & min_detections
 	candidate: None | dict[str, Any] = None


### PR DESCRIPTION
The int type made that any time ranges shorter than a day was rounded to zero. 